### PR TITLE
Fixed Build Error - Incorrect Header

### DIFF
--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -5,7 +5,7 @@
 //  Copyright © 2016 Branch Metrics. All rights reserved.
 //
 
-#import <Branch/Branch.h>
+#import "BranchSDK.h"
 
 @interface BranchSDK()
 


### PR DESCRIPTION
The Header imported is not correct which causes a build error.