### PR TITLE
Handled Crash due to empty Context

### DIFF
--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -549,12 +549,12 @@ public class BranchSDK extends CordovaPlugin
         this.activity = this.cordova.getActivity();
 
         // Handled Random Crash due to empty context
-        if (this.activity != null && this.activity.getApplicationContext() != null) {
-            Branch debugInstance = Branch.getAutoInstance(this.activity.getApplicationContext());
-            if (isEnable) {
-                debugInstance.setDebug();
-            }
-        }
+//        if (this.activity != null && this.activity.getApplicationContext() != null) {
+//            Branch debugInstance = Branch.getAutoInstance(this.activity.getApplicationContext());
+//            if (isEnable) {
+//                debugInstance.setDebug();
+//            }
+//        }
 
         callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, /* send boolean: false as the data */ isEnable));
     }

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -548,10 +548,12 @@ public class BranchSDK extends CordovaPlugin
 
         this.activity = this.cordova.getActivity();
 
-        Branch debugInstance = Branch.getAutoInstance(this.activity.getApplicationContext());
-
-        if (isEnable) {
-            debugInstance.setDebug();
+        // Handled Random Crash due to empty context
+        if (this.activity != null && this.activity.getApplicationContext() != null) {
+            Branch debugInstance = Branch.getAutoInstance(this.activity.getApplicationContext());
+            if (isEnable) {
+                debugInstance.setDebug();
+            }
         }
 
         callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, /* send boolean: false as the data */ isEnable));


### PR DESCRIPTION
The was crashing sometime randomly when user returns to app using a link. 
This was tested for twitter and facebook. The app instance is cleared before clicking the deep link.