### PR TITLE
fix: Create path for Crashlytics harmony

### DIFF
--- a/build-branch-extras.gradle
+++ b/build-branch-extras.gradle
@@ -1,5 +1,3 @@
 dependencies {
-	compile ('io.branch.sdk.android:library:2.+') {
-	    exclude module: 'answers-shim'
-	}
+	compile ('io.branch.sdk.android:library:2.+')
 }

--- a/build-branch-extras.gradle
+++ b/build-branch-extras.gradle
@@ -1,0 +1,5 @@
+dependencies {
+	compile ('io.branch.sdk.android:library:2.+') {
+	    exclude module: 'answers-shim'
+	}
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -76,7 +76,8 @@ SOFTWARE.
             </intent-filter>
         </config-file>
         <source-file src="src/android/io/branch/BranchSDK.java" target-dir="src/io/branch" />
-        <framework src="io.branch.sdk.android:library:1+" />
+         <!-- <framework src="io.branch.sdk.android:library:2+" /> -->
+        <framework src="build-branch-extras.gradle" custom="true" type="gradleReference" />
     </platform>
 
     <!-- ios -->


### PR DESCRIPTION
In reference to https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking/issues/208, it's super hard to fix library conflicts with the current method of dropping in the Android SDK. This creates a gradle extension file that can be easily changed in the platform directory.

@renesansz @amit-bansil 