### PR TITLE
feat: use es6-promise-plugin from npm instead of github

### DIFF
--- a/plugin.template.xml
+++ b/plugin.template.xml
@@ -34,10 +34,10 @@ SOFTWARE.
     <keywords>cordova,branch</keywords>
     <repo>https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK.git</repo>
     <issue>https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK/issues</issue>
-    
+
     <dependency
       id="es6-promise-plugin"
-      url="https://github.com/vstirbu/PromisesPlugin.git">
+      version="3.0.2">
     </dependency>
 
     <js-module src="www/branch.js" name="Branch">

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,7 @@ SOFTWARE.
 
     <dependency
       id="es6-promise-plugin"
-      url="https://github.com/vstirbu/PromisesPlugin.git">
+      version="3.0.2">
     </dependency>
 
     <js-module src="www/branch.js" name="Branch">


### PR DESCRIPTION
Fetching from npm assures always using the same version
(more stable and reproducible builds) and is generally much faster
than cloning from github (particularly in enterprise env
with private npm repo)

I opened this PR because today fetching the es6 plugin from github is failing a lot:

```
Installing "io.branch.sdk" for android
Fetching plugin "https://github.com/vstirbu/PromisesPlugin.git" via git clone
Failed to install 'io.branch.sdk':CordovaError: Failed to fetch plugin https://github.com/vstirbu/PromisesPlugin.git via git.
Either there is a connection problems, or plugin spec is incorrect:
        Error: C:\Program Files (x86)\Git\bin\git.exe: Command failed with exit code 128 Error output:
...
fatal: unable to access 'https://github.com/vstirbu/PromisesPlugin.git/': Failed to connect to github.com port 443: Timed out
```