### PR TITLE
iOS fix shareTitle and shareText

### DIFF
--- a/src/ios/dependencies/Branch-SDK/BranchUniversalObject.m
+++ b/src/ios/dependencies/Branch-SDK/BranchUniversalObject.m
@@ -184,7 +184,7 @@
     UIActivityItemProvider *itemProvider = [self getBranchActivityItemWithLinkProperties:linkProperties];
     NSMutableArray *items = [NSMutableArray arrayWithObject:itemProvider];
     if (shareText) {
-        [items insertObject:shareText atIndex:0];
+        [items insertObject:[shareText valueForKey:@"shareText"] atIndex:0];
     }
     UIActivityViewController *shareViewController = [[UIActivityViewController alloc] initWithActivityItems:items applicationActivities:nil];
     
@@ -223,6 +223,13 @@
         }
         @catch (NSException *exception) {
             [_preferenceHelper logWarning:@"Unable to setValue 'emailSubject' forKey 'subject' on UIActivityViewController."];
+        }
+    } else if ([shareText valueForKey:@"shareTitle"] != nil) {
+        @try {
+            [shareViewController setValue:[shareText valueForKey:@"shareTitle"] forKey:@"subject"];
+        }
+        @catch (NSException *exception) {
+            [_preferenceHelper logWarning:@"Unable to setValue 'emailSubject' forKey 'subject' on UIActivityViewController as shareTitle is missing"];
         }
     }
     


### PR DESCRIPTION
This fix allows the ability to handle the shareTitle for email client and choose specific text when contentMetaData is provided from the UI call.

In reference to Android fix https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking/commit/aa2dfcc18d5c6d9e0c8105abf07aa5a535910ef5
