### PR TITLE
Add missing framework CoreSpotlight.framework dependency on ios

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -105,14 +105,14 @@ SOFTWARE.
         <header-file src="src/ios/BranchSDK.h" />
         <source-file src="src/ios/BranchSDK.m" />
         <source-file src="src/ios/AppDelegate+BranchSdk.m" />
-        
+
         <header-file src="src/ios/dependencies/Fabric/ANSCompatibility.h" />
         <header-file src="src/ios/dependencies/Fabric/Answers.h" />
         <header-file src="src/ios/dependencies/Fabric/FABAttributes.h" />
         <header-file src="src/ios/dependencies/Fabric/FABKitProtocol.h" />
         <header-file src="src/ios/dependencies/Fabric/Fabric+FABKits.h" />
         <header-file src="src/ios/dependencies/Fabric/Fabric.h" />
-        
+
         <header-file src="src/ios/dependencies/Branch-SDK/BNCCallbacks.h" />
         <header-file src="src/ios/dependencies/Branch-SDK/BNCConfig.h" />
         <header-file src="src/ios/dependencies/Branch-SDK/BNCContentDiscoveryManager.h" />
@@ -167,7 +167,7 @@ SOFTWARE.
         <source-file src="src/ios/dependencies/Branch-SDK/BranchView.m" />
         <header-file src="src/ios/dependencies/Branch-SDK/BranchViewHandler.h" />
         <source-file src="src/ios/dependencies/Branch-SDK/BranchViewHandler.m" />
-        
+
         <header-file src="src/ios/dependencies/Branch-SDK/Requests/BNCServerRequest.h" />
         <source-file src="src/ios/dependencies/Branch-SDK/Requests/BNCServerRequest.m" />
         <header-file src="src/ios/dependencies/Branch-SDK/Requests/BranchCloseRequest.h" />
@@ -197,6 +197,7 @@ SOFTWARE.
         <header-file src="src/ios/dependencies/Branch-SDK/Requests/BranchUserCompletedActionRequest.h" />
         <source-file src="src/ios/dependencies/Branch-SDK/Requests/BranchUserCompletedActionRequest.m" />
         <header-file src="src/ios/dependencies/Branch-SDK/Requests/PromoViewHandler.h" />
-        
+
+        <framework src="CoreSpotlight.framework"/>
     </platform>
 </plugin>


### PR DESCRIPTION
It appears the branch ios sdk is dependent on CoreSpotlight.framework to build but the plugin does not automatically add this in. This change to the plugin.xml should ensure that the framework is added when the plugin is installed.