### PR TITLE
fix: add "use strict"; to make plugin work with node 5

### DIFF
--- a/src/scripts/android/updateAndroidManifest.js
+++ b/src/scripts/android/updateAndroidManifest.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
   // properties
 

--- a/src/scripts/hooks/afterPrepare.js
+++ b/src/scripts/hooks/afterPrepare.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
   // properties
 

--- a/src/scripts/hooks/beforePluginInstall.js
+++ b/src/scripts/hooks/beforePluginInstall.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
   // properties
 

--- a/src/scripts/hooks/beforePrepare.js
+++ b/src/scripts/hooks/beforePrepare.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
   // properties
 

--- a/src/scripts/ios/enableEntitlements.js
+++ b/src/scripts/ios/enableEntitlements.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
   // properties
 

--- a/src/scripts/ios/updateAssociatedDomains.js
+++ b/src/scripts/ios/updateAssociatedDomains.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
   // properties
 

--- a/src/scripts/ios/updateDevelopmentTeam.js
+++ b/src/scripts/ios/updateDevelopmentTeam.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
   // properties
 

--- a/src/scripts/ios/updatePlist.js
+++ b/src/scripts/ios/updatePlist.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
   // properties
 

--- a/src/scripts/lib/fileHelper.js
+++ b/src/scripts/lib/fileHelper.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
   // properties
 

--- a/src/scripts/lib/xmlHelper.js
+++ b/src/scripts/lib/xmlHelper.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
   // properties
 

--- a/src/scripts/npm/downloadNpmDependencies.js
+++ b/src/scripts/npm/downloadNpmDependencies.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
   // properties
 

--- a/src/scripts/npm/processConfigXml.js
+++ b/src/scripts/npm/processConfigXml.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
   // properties
 

--- a/src/scripts/npm/updateChangeLog.js
+++ b/src/scripts/npm/updateChangeLog.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // TODO: test git push
 // TODO: early exit based on last changelog version
 // TODO: 'Authorization': 'token xxxx', for testing

--- a/src/scripts/npm/updateNpmVersion.js
+++ b/src/scripts/npm/updateNpmVersion.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
   // properties
 


### PR DESCRIPTION
Hi,
we are using node 5.12.0 and encountered this build error when trying to update to the new version (3.0.0):
`Error: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode`

So we added strict to the build files.