### PR TITLE
Fix: iOS disableTracking can now also be used to enable tracking

### DIFF
--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -121,7 +121,7 @@
 - (void)disableTracking:(CDVInvokedUrlCommand*)command
 {
 
-  bool enabled = [[command.arguments objectAtIndex:0] boolValue] == YES;
+  bool enabled = [[command.arguments objectAtIndex:0] boolValue];
   [Branch setTrackingDisabled:enabled];
 
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:enabled];

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -122,9 +122,7 @@
 {
 
   bool enabled = [[command.arguments objectAtIndex:0] boolValue] == YES;
-  if (enabled) {
-    [Branch setTrackingDisabled:enabled];
-  }
+  [Branch setTrackingDisabled:enabled];
 
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:enabled];
 


### PR DESCRIPTION
The Android version of the plugin allows this behaviour so presumably iOS should as well.