### PR TITLE
docs: make it clear that create deeplink and share deeplink function's parameters are mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ _Questions? [Contact us](https://support.branch.io/support/tickets/new)_
 
   * Verify on the [Branch Dashboard](https://dashboard.branch.io/liveview/links)
 
+  * All function's parameters are mandatory 
+
     ```js
     // optional fields
     var analytics = {
@@ -366,6 +368,8 @@ _Questions? [Contact us](https://support.branch.io/support/tickets/new)_
   * Needs a [Branch Universal Object](#create-content-reference)
 
   * Link Data: [Deep Link Properties](#link-data-deep-link-properties)
+
+  * All function's parameters are mandatory 
 
     ```js
     // optional fields


### PR DESCRIPTION
While trying to implement this plugin with my team we found out its not perfectly clear that the showShareSheet() and generateShortUrl() functions' parameters are mandatory in the docs. 