### PR TITLE
fix: Use Cordova iOS podspec instead dependency plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -69,8 +69,7 @@ SOFTWARE.
 
   <!-- iOS -->
   <platform name="ios">
-    <pods-config ios-min-version="9.0" use-frameworks="true" />
-    <pod name="Branch" />
+    <framework src="Branch" type="podspec" spec="~> 0.25.8" />
 
     <config-file target="config.xml" parent="/*">
       <feature name="BranchSDK">
@@ -83,10 +82,6 @@ SOFTWARE.
     <header-file src="src/ios/BranchSDK.h" />
     <source-file src="src/ios/BranchSDK.m" />
     <source-file src="src/ios/AppDelegate+BranchSdk.m" />
-
-
-    <dependency id="cordova-plugin-cocoapod-support" />
-
   
   </platform>
 </plugin>


### PR DESCRIPTION
I added a PR to use CocoaPods directly and used a plugin for that. I think it would be better to use Cordova iOS feature for it instead of a dependency plugin.

See: https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#framework -> type="podspec"

At the moment I do not know if this is working, so it would be great if someone can test it. Furthermore I do not know if spec (for the version) is required

UPDATE: spec  is required, but i do not know how to get the latest version :(

As mentioned in #529 if the hook is active, branch will not be added as cordova plugin (i do not know why)

Anyone who wants to test it, take a look at https://www.npmjs.com/package/innomobile-branch-cordova-sdk (`cordova plugin add innomobile-branch-cordova-sdk`)