### PR TITLE
feat: Use CocoaPods directly from Cordova iOS - Remove broken hook

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,9 +37,11 @@ SOFTWARE.
   <issue>https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK/issues</issue>
 
   <!-- Dependencies -->
-  <engines>
-    <engine name="cordova" version=">=3.5.0" />
-  </engines>
+<engines>
+    <engine name="cordova" version=">=7.0.0" />
+    <engine name="cordova-android" version=">=6.3.0" />
+    <engine name="cordova-ios" version=">=4.4.0" />
+</engines>
 
   <!-- Hooks -->
   <hook src="src/scripts/hooks/beforePluginInstall.js" type="before_plugin_install" />
@@ -69,8 +71,7 @@ SOFTWARE.
 
   <!-- iOS -->
   <platform name="ios">
-    <pods-config ios-min-version="9.0" use-frameworks="true" />
-    <pod name="Branch" />
+    <framework src="Branch" type="podspec" spec="~> 0.25.8" />
 
     <config-file target="config.xml" parent="/*">
       <feature name="BranchSDK">
@@ -83,10 +84,6 @@ SOFTWARE.
     <header-file src="src/ios/BranchSDK.h" />
     <source-file src="src/ios/BranchSDK.m" />
     <source-file src="src/ios/AppDelegate+BranchSdk.m" />
-
-
-    <dependency id="cordova-plugin-cocoapod-support" />
-
   
   </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -71,7 +71,7 @@ SOFTWARE.
 
   <!-- iOS -->
   <platform name="ios">
-    <framework src="Branch" type="podspec" spec="0.25.9" />
+    <framework src="Branch" type="podspec" spec="0.25.8" />
 
     <config-file target="config.xml" parent="/*">
       <feature name="BranchSDK">

--- a/plugin.xml
+++ b/plugin.xml
@@ -71,7 +71,7 @@ SOFTWARE.
 
   <!-- iOS -->
   <platform name="ios">
-    <framework src="Branch" type="podspec" spec="~> 0.25.8" />
+    <framework src="Branch" type="podspec" spec="0.25.9" />
 
     <config-file target="config.xml" parent="/*">
       <feature name="BranchSDK">


### PR DESCRIPTION
Based on my PR #527 this PR will add CocoaPods directly from Cordova iOS (no need for a third party cordova plugin anymore). Furthermore it removes the broken install hook (see #529) which leads that the branch cordova plugin will not be added as plugin to Android and iOS

More information about the cordova iOS Podspec here -> See: https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#framework -> type="podspec"

The spec attribute is required, but I don't know how to get the latest version of Branch automatically

Anyone who wants to test it, take a look at https://www.npmjs.com/package/innomobile-branch-cordova-sdk (`cordova plugin add innomobile-branch-cordova-sdk`)