### PR TITLE
SDK-215 Use older gradle syntax for improved backwards compatibility

### DIFF
--- a/src/android/dependencies/rules.gradle
+++ b/src/android/dependencies/rules.gradle
@@ -1,4 +1,11 @@
 dependencies {
-    implementation fileTree(dir: 'libs', include: '*.aar')
+    compile (name:'Branch', ext:'aar')
 }
+repositories {
+    flatDir {
+        dirs 'libs'
+    }
+}
+
+
 

--- a/src/android/dependencies/rules.gradle
+++ b/src/android/dependencies/rules.gradle
@@ -3,7 +3,7 @@ dependencies {
 }
 repositories {
     flatDir {
-        dirs 'libs'
+        dirs 'app/libs'
     }
 }
 


### PR DESCRIPTION
This fixes an issue with older versions of cordova having issues resolving the branch aar.